### PR TITLE
Wallpaper Support (+ friends)

### DIFF
--- a/src/compositor/scene.c
+++ b/src/compositor/scene.c
@@ -1,9 +1,11 @@
 #include "scene.h"
 
 struct wlr_scene* catnip_scene = NULL;
+struct wlr_scene_tree* catnip_scene_wallpaper_layer = NULL;
 
 void
 catnip_scene_init()
 {
   catnip_scene = wlr_scene_create();
+  catnip_scene_wallpaper_layer = wlr_scene_tree_create(&catnip_scene->tree);
 }

--- a/src/compositor/scene.c
+++ b/src/compositor/scene.c
@@ -2,10 +2,12 @@
 
 struct wlr_scene* catnip_scene = NULL;
 struct wlr_scene_tree* catnip_scene_wallpaper_layer = NULL;
+struct wlr_scene_tree* catnip_scene_desktop_layer = NULL;
 
 void
 catnip_scene_init()
 {
   catnip_scene = wlr_scene_create();
   catnip_scene_wallpaper_layer = wlr_scene_tree_create(&catnip_scene->tree);
+  catnip_scene_desktop_layer = wlr_scene_tree_create(&catnip_scene->tree);
 }

--- a/src/compositor/scene.h
+++ b/src/compositor/scene.h
@@ -4,6 +4,7 @@
 #include <wlr/types/wlr_scene.h>
 
 extern struct wlr_scene* catnip_scene;
+extern struct wlr_scene_tree* catnip_scene_wallpaper_layer;
 
 void
 catnip_scene_init();

--- a/src/compositor/scene.h
+++ b/src/compositor/scene.h
@@ -5,6 +5,7 @@
 
 extern struct wlr_scene* catnip_scene;
 extern struct wlr_scene_tree* catnip_scene_wallpaper_layer;
+extern struct wlr_scene_tree* catnip_scene_desktop_layer;
 
 void
 catnip_scene_init();

--- a/src/desktop/lua_output.h
+++ b/src/desktop/lua_output.h
@@ -7,6 +7,7 @@
 struct catnip_lua_output {
   lua_Ref ref;
   lua_Ref subscriptions;
+  lua_Ref wallpaper;
   struct wl_list link;
   struct catnip_output* output;
   struct catnip_lua_output_modes* lua_output_modes;

--- a/src/desktop/window.c
+++ b/src/desktop/window.c
@@ -103,7 +103,7 @@ catnip_window_create(struct wlr_xdg_toplevel* xdg_toplevel)
   window->id = generate_catnip_id();
   window->wlr.xdg_toplevel = xdg_toplevel;
   window->wlr.scene_tree =
-    wlr_scene_xdg_surface_create(&catnip_scene->tree, xdg_surface);
+    wlr_scene_xdg_surface_create(catnip_scene_desktop_layer, xdg_surface);
 
   // wlroots provides a helper for adding xdg popups to the scene graph, but
   // it requires the popup parent's scene node. For convenience, we always

--- a/src/widget/lua_widget_block.c
+++ b/src/widget/lua_widget_block.c
@@ -187,10 +187,15 @@ catnip_lua_widget_block__newindex(lua_State* L)
     }
 
     lua_rawgeti(L, LUA_REGISTRYINDEX, block->children);
-    lua_rawgeti(L, -1, position);
 
+    lua_rawgeti(L, -1, position);
     struct catnip_lua_widget_base* old_child = lua_touserdata(L, -1);
-    old_child->parent = NULL;
+
+    if (old_child != NULL) {
+      old_child->parent = NULL;
+    }
+
+    lua_pop(L, 1);
 
     struct catnip_lua_widget_base* new_child = lua_touserdata(L, 3);
     new_child->parent = &block->base;

--- a/src/widget/lua_widget_block.c
+++ b/src/widget/lua_widget_block.c
@@ -3,9 +3,27 @@
 #include "extensions/string.h"
 #include "widget/lua_widget_base.h"
 #include "widget/lua_widget_png.h"
+#include "widget/lua_widget_root.h"
 #include "widget/lua_widget_svg.h"
 #include "widget/lua_widget_text.h"
 #include <lauxlib.h>
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+static struct catnip_lua_widget_block*
+catnip_lua_widget_block_check(lua_State* L, int idx)
+{
+  enum catnip_lua_widget_type widget_type = catnip_lua_widget_base_type(L, idx);
+
+  if (widget_type == CATNIP_LUA_WIDGET_ROOT) {
+    struct catnip_lua_widget_root* root = lua_touserdata(L, idx);
+    return root->block;
+  } else {
+    return luaL_checkudata(L, idx, "catnip.widget.block");
+  }
+}
 
 // -----------------------------------------------------------------------------
 // Lua Methods
@@ -16,8 +34,7 @@ catnip_lua_widget_block_lua_insert(lua_State* L)
 {
   int num_args = lua_gettop(L);
 
-  struct catnip_lua_widget_block* block =
-    luaL_checkudata(L, 1, "catnip.widget.block");
+  struct catnip_lua_widget_block* block = catnip_lua_widget_block_check(L, 1);
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, block->children);
   int children_len = lua_objlen(L, -1);
@@ -73,8 +90,7 @@ catnip_lua_widget_block_lua_insert(lua_State* L)
 static int
 catnip_lua_widget_block_lua_remove(lua_State* L)
 {
-  struct catnip_lua_widget_block* block =
-    luaL_checkudata(L, 1, "catnip.widget.block");
+  struct catnip_lua_widget_block* block = catnip_lua_widget_block_check(L, 1);
 
   lua_rawgeti(L, LUA_REGISTRYINDEX, block->children);
   int children_len = lua_objlen(L, -1);

--- a/src/widget/lua_widget_block.c
+++ b/src/widget/lua_widget_block.c
@@ -212,7 +212,7 @@ catnip_lua_widget_block__newindex(lua_State* L)
     luaL_checktype(L, 3, LUA_TFUNCTION);
     luaL_unref(L, LUA_REGISTRYINDEX, block->styles.layout);
     lua_pushvalue(L, 3);
-    luaL_ref(L, block->styles.layout);
+    block->styles.layout = luaL_ref(L, LUA_REGISTRYINDEX);
   } else if (streq(key, "padding")) {
     block->styles.padding = luaL_checknumber(L, 3);
     catnip_lua_widget_base_request_layout(L, &block->base);

--- a/src/widget/lua_widget_root.c
+++ b/src/widget/lua_widget_root.c
@@ -220,7 +220,7 @@ catnip_lua_widget_lua_root(lua_State* L)
   );
 
   root->wlr.scene_buffer =
-    wlr_scene_buffer_create(&catnip_scene->tree, &root->wlr.buffer);
+    wlr_scene_buffer_create(catnip_scene_desktop_layer, &root->wlr.buffer);
 
   root->request.event_source = NULL;
   root->request.width = initial_width;

--- a/src/widget/lua_widget_root.c
+++ b/src/widget/lua_widget_root.c
@@ -3,6 +3,7 @@
 #include "compositor/scene.h"
 #include "config.h"
 #include "extensions/string.h"
+#include "extensions/wlroots.h"
 #include "widget/lua_widget_block.h"
 #include <drm_fourcc.h>
 #include <lauxlib.h>
@@ -73,6 +74,8 @@ catnip_lua_widget_root__index(lua_State* L)
     lua_pushnumber(L, root->wlr.scene_buffer->node.x);
   } else if (streq(key, "y")) {
     lua_pushnumber(L, root->wlr.scene_buffer->node.y);
+  } else if (streq(key, "z")) {
+    lua_pushnumber(L, wlr_scene_node_get_zindex(&root->wlr.scene_buffer->node));
   } else if (streq(key, "width")) {
     lua_pushnumber(L, root->wlr.buffer.width);
   } else if (streq(key, "height")) {
@@ -117,6 +120,11 @@ catnip_lua_widget_root__newindex(lua_State* L)
     wlr_scene_node_set_position(
       &root->wlr.scene_buffer->node,
       root->wlr.scene_buffer->node.x,
+      luaL_checkinteger(L, 3)
+    );
+  } else if (streq(key, "z")) {
+    wlr_scene_node_set_zindex(
+      &root->wlr.scene_buffer->node,
       luaL_checkinteger(L, 3)
     );
   } else if (streq(key, "width")) {


### PR DESCRIPTION
Adds support for an `output.wallpaper` widget field that by default layouts all children to stretch over the output.

Additionally, adds some other small features / bug fixes, see commits for all changes.

Closes https://github.com/bsuth/catnip/issues/5